### PR TITLE
Update Rust version in Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
-    rust: "1.61"
+    rust: "1.64"
 
 python:
   install:


### PR DESCRIPTION
Read the Docs [failed to build](https://readthedocs.org/projects/python-vaporetto/builds/19955728/), so this branch updates Rust to 1.64 in CI.
1.64 is already supported: https://docs.readthedocs.io/en/stable/config-file/v2.html