### PR TITLE
Update actions/{upload,download}-artifact to v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
       uses: PyO3/maturin-action@v1
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         target: [ x86_64, i686 ]
     steps:
     - uses: actions/checkout@v3
@@ -91,7 +91,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         target: [ x64, x86 ]
     steps:
     - uses: actions/checkout@v3
@@ -118,7 +118,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,9 +54,9 @@ jobs:
       with:
         command: sdist
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.runs-on }}
         path: target/wheels
 
   pack-linux:
@@ -80,9 +80,9 @@ jobs:
         manylinux: auto
         args: -i ${{ matrix.python-version }} --release
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.runs-on }}
         path: target/wheels
 
   pack-windows:
@@ -107,9 +107,9 @@ jobs:
         manylinux: auto
         args: -i ${{ matrix.python-version }} --release
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.runs-on }}
         path: target/wheels
 
   pack-macos:
@@ -132,9 +132,9 @@ jobs:
         manylinux: auto
         args: -i ${{ matrix.python-version }} --release --universal2
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.runs-on }}
         path: target/wheels
 
   release:
@@ -143,9 +143,10 @@ jobs:
     needs: [ pack-sdist, pack-linux, pack-windows, pack-macos ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          merge-multiple: true
       - name: Publish to PyPI
         uses: messense/maturin-action@v1
         env:

--- a/tests/test_comparison_cat.py
+++ b/tests/test_comparison_cat.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import vaporetto
-import Mykytea
-from sudachipy import tokenizer as sudachi_tokenizer
+import Mykytea  # type: ignore[import-not-found]
+from sudachipy import tokenizer as sudachi_tokenizer  # type: ignore[import-not-found]
 from sudachipy import dictionary as sudachi_dictionary
 
-from pytest_benchmark import fixture
+from pytest_benchmark import fixture  # type: ignore[import-not-found]
 from tests import dataset
 
 

--- a/tests/test_comparison_cat.py
+++ b/tests/test_comparison_cat.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import vaporetto
-import Mykytea  # type: ignore[import]
-from sudachipy import tokenizer as sudachi_tokenizer  # type: ignore[import]
+import Mykytea
+from sudachipy import tokenizer as sudachi_tokenizer
 from sudachipy import dictionary as sudachi_dictionary
 
-from pytest_benchmark import fixture  # type: ignore[import]
+from pytest_benchmark import fixture
 from tests import dataset
 
 

--- a/tests/test_comparison_count.py
+++ b/tests/test_comparison_count.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import vaporetto
-import Mykytea
-from sudachipy import tokenizer as sudachi_tokenizer
+import Mykytea  # type: ignore[import-not-found]
+from sudachipy import tokenizer as sudachi_tokenizer  # type: ignore[import-not-found]
 from sudachipy import dictionary as sudachi_dictionary
 
-from pytest_benchmark import fixture
+from pytest_benchmark import fixture  # type: ignore[import-not-found]
 from tests import dataset
 
 

--- a/tests/test_comparison_count.py
+++ b/tests/test_comparison_count.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import vaporetto
-import Mykytea  # type: ignore[import]
-from sudachipy import tokenizer as sudachi_tokenizer  # type: ignore[import]
+import Mykytea
+from sudachipy import tokenizer as sudachi_tokenizer
 from sudachipy import dictionary as sudachi_dictionary
 
-from pytest_benchmark import fixture  # type: ignore[import]
+from pytest_benchmark import fixture
 from tests import dataset
 
 


### PR DESCRIPTION
Deprecation notice: v3 of the artifact actions
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Migration guide https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md